### PR TITLE
Add instance ElmType Int32, remove ElmType Int

### DIFF
--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -8,6 +8,7 @@
 
 module Elm.Type where
 
+import           Data.Int     (Int32)
 import           Data.Map
 import           Data.Proxy
 import           Data.Text
@@ -171,7 +172,7 @@ class HasElmComparable a where
 instance HasElmComparable String where
   toElmComparable _ = EString
 
-instance ElmType Int where
+instance ElmType Int32 where
   toElmType _ = ElmPrimitive EInt
 
 instance ElmType Char where

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -5,6 +5,7 @@
 module ExportSpec where
 
 import           Data.Char
+import           Data.Int
 import           Data.Map
 import           Data.Monoid
 import           Data.Proxy
@@ -22,7 +23,7 @@ import           Text.Printf
 -- ...
 
 data Post = Post
-    { id       :: Int
+    { id       :: Int32
     , name     :: String
     , age      :: Maybe Double
     , comments :: [Comment]
@@ -31,12 +32,12 @@ data Post = Post
     } deriving (Generic, ElmType)
 
 data Comment = Comment
-    { postId         :: Int
+    { postId         :: Int32
     , text           :: Text
     , mainCategories :: (String, String)
     , published      :: Bool
     , created        :: UTCTime
-    , tags           :: Map String Int
+    , tags           :: Map String Int32
     } deriving (Generic, ElmType)
 
 data Position


### PR DESCRIPTION
Elm's 'Int' type is a 32 bit two's complement integer. The size of
Haskell's Int type is unspecified and there may not be an isomorphism
between the two. Int32 however is always safe.

This deserves a version bump. I'm not too clear on how to branches and features are being handled at the moment. Feel free to cherry-pick onto a more appropriate branch.
